### PR TITLE
Fix not to list matched post

### DIFF
--- a/api/nexus-typegen.ts
+++ b/api/nexus-typegen.ts
@@ -125,6 +125,7 @@ export interface NexusGenFieldTypes {
   }
   Mutation: { // field return type
     authGithub: NexusGenRootTypes['AuthPayLoad']; // AuthPayLoad!
+    completePairProgramming: NexusGenRootTypes['Post']; // Post!
     createCommunity: NexusGenRootTypes['Community']; // Community!
     createMessage: NexusGenRootTypes['Message']; // Message!
     deleteCommunity: NexusGenRootTypes['Community']; // Community!
@@ -219,6 +220,7 @@ export interface NexusGenFieldTypeNames {
   }
   Mutation: { // field return type name
     authGithub: 'AuthPayLoad'
+    completePairProgramming: 'Post'
     createCommunity: 'Community'
     createMessage: 'Message'
     deleteCommunity: 'Community'
@@ -295,6 +297,9 @@ export interface NexusGenArgTypes {
   Mutation: {
     authGithub: { // args
       code: string; // String!
+    }
+    completePairProgramming: { // args
+      postId: string; // String!
     }
     createCommunity: { // args
       name: string; // String!

--- a/api/nexus-typegen.ts
+++ b/api/nexus-typegen.ts
@@ -167,6 +167,7 @@ export interface NexusGenFieldTypes {
     feed: NexusGenRootTypes['Post'][]; // [Post!]!
     messagesByPostId: NexusGenRootTypes['Message'][]; // [Message!]!
     myCommunities: NexusGenRootTypes['Community'][]; // [Community!]!
+    myCompletedPosts: NexusGenRootTypes['Post'][]; // [Post!]!
     myCurrentCommunity: NexusGenRootTypes['Community'] | null; // Community
     myDrivingPosts: NexusGenRootTypes['Post'][]; // [Post!]!
     myMatchedPosts: NexusGenRootTypes['Post'][]; // [Post!]!
@@ -262,6 +263,7 @@ export interface NexusGenFieldTypeNames {
     feed: 'Post'
     messagesByPostId: 'Message'
     myCommunities: 'Community'
+    myCompletedPosts: 'Post'
     myCurrentCommunity: 'Community'
     myDrivingPosts: 'Post'
     myMatchedPosts: 'Post'

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -32,6 +32,7 @@ type Message {
 
 type Mutation {
   authGithub(code: String!): AuthPayLoad!
+  completePairProgramming(postId: String!): Post!
   createCommunity(name: String!): Community!
   createMessage(content: String!, postId: String!): Message!
   deleteCommunity(communityId: String!): Community!

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -77,6 +77,7 @@ type Query {
   feed: [Post!]!
   messagesByPostId(postId: String!): [Message!]!
   myCommunities(skip: Int, take: Int): [Community!]!
+  myCompletedPosts: [Post!]!
   myCurrentCommunity: Community
   myDrivingPosts: [Post!]!
   myMatchedPosts: [Post!]!

--- a/api/src/graphql/Post.ts
+++ b/api/src/graphql/Post.ts
@@ -60,6 +60,7 @@ export const PostQuery = extendType({
         return context.prisma.post.findMany();
       },
     });
+
     t.field("post", {
       type: "Post",
       args: {
@@ -72,6 +73,7 @@ export const PostQuery = extendType({
         });
       },
     });
+
     t.nonNull.list.nonNull.field("unmatchedPosts", {
       type: "Post",
       args: {
@@ -129,6 +131,7 @@ export const PostQuery = extendType({
         });
       },
     });
+
     t.nonNull.list.nonNull.field("myDrivingPosts", {
       type: "Post",
       resolve(parent, args, context) {
@@ -145,6 +148,7 @@ export const PostQuery = extendType({
         });
       },
     });
+
     t.nonNull.list.nonNull.field("myMatchedPosts", {
       type: "Post",
       resolve(parent, args, context) {
@@ -158,7 +162,7 @@ export const PostQuery = extendType({
             OR: [{ navigatorId: profileId }, { driverId: profileId }],
             navigatorId: { not: null },
             driverId: { not: null },
-            completedAt: null
+            completedAt: null,
           },
         });
       },
@@ -345,10 +349,10 @@ export const PostMutation = extendType({
       },
     });
 
-    t.nonNull.field('completePairProgramming', {
-      type: 'Post',
+    t.nonNull.field("completePairProgramming", {
+      type: "Post",
       args: {
-        postId: nonNull(stringArg())
+        postId: nonNull(stringArg()),
       },
       async resolve(parent, args, context) {
         const { postId } = args;
@@ -361,12 +365,14 @@ export const PostMutation = extendType({
         }
 
         const post = await context.prisma.post.findUnique({
-          where: { id: postId }
+          where: { id: postId },
         });
 
         if (!post) {
           throw new Error("There is no such Post");
-        } else if (!(profileId == post.driverId || profileId == post.navigatorId)) {
+        } else if (
+          !(profileId == post.driverId || profileId == post.navigatorId)
+        ) {
           throw new Error("You do not have rights to complete this post.");
         } else if (post.navigatorId == null) {
           throw new Error("This post is not matched yet.");
@@ -377,10 +383,10 @@ export const PostMutation = extendType({
         return context.prisma.post.update({
           where: { id: postId },
           data: {
-            completedAt: new Date()
+            completedAt: new Date(),
           },
         });
-      }
-    })
+      },
+    });
   },
 });

--- a/api/src/graphql/Post.ts
+++ b/api/src/graphql/Post.ts
@@ -167,6 +167,24 @@ export const PostQuery = extendType({
         });
       },
     });
+
+    t.nonNull.list.nonNull.field("myCompletedPosts", {
+      type: "Post",
+      resolve(parent, args, context) {
+        const { profileId } = context;
+        if (!profileId) {
+          throw new Error("You have to log in");
+        }
+        return context.prisma.post.findMany({
+          where: {
+            OR: [{ navigatorId: profileId }, { driverId: profileId }],
+            navigatorId: { not: null },
+            driverId: { not: null },
+            completedAt: { not: null },
+          },
+        });
+      },
+    });
   },
 });
 


### PR DESCRIPTION
closes #150
closes #138 
closes #121 

## 変更点
myMatchedPost queryではcompletedAtがnullのときのみ表示するようにした

## 追加されたリゾルバ
- completePairProgramming(postId: String!) postIdを指定してペアプロ完了する
- myCompletedPosts: [Post!]! ペアプロ完了済みPostの表示

## 試験した観点

headerが空の時にエラーを出すか
PostIDが間違っている時にエラー
権限がないときにエラーを出すか
ナビゲーターが空の時にエラーを出すか
すでにcompleteしたPostを指定した時にエラーを出すか
条件を満たした時にcompletedAtを埋められるか

myMatchedPostがcompletedAtがNullでマッチングが完了しているPostのみを表示していること

registerNavigatorがcompletedAtカラムに変更を与えないこと

MyCompletedPostsが、completedAtがnonnullなPostを表示していること

## その他
updatePostで、requiredSkillsのupdateができていなかったので、修正。

### 仕様、試験したこと
requiredSkillsIds parameterに何も値をしていしない or null のとき、値を更新しない
requiredSkillsIds parameterに [] を指定した時、requiredSkills は空になる
requiredSkillsIds parameterに [1, 2 ] を指定した時、requiredSkills は id 1, 2 のskillになる