### PR TITLE
Statistics of reviewers

### DIFF
--- a/api/nexus-typegen.ts
+++ b/api/nexus-typegen.ts
@@ -61,6 +61,10 @@ export interface NexusGenObjects {
     id: number; // Int!
   }
   Mutation: {};
+  PairProgrammingCount: { // root type
+    count: number; // Int!
+    profile: NexusGenRootTypes['Profile']; // Profile!
+  }
   Post: { // root type
     completedAt?: NexusGenScalars['DateTime'] | null; // DateTime
     createdAt: NexusGenScalars['DateTime']; // DateTime!
@@ -137,6 +141,10 @@ export interface NexusGenFieldTypes {
     updateMyProfile: NexusGenRootTypes['Profile'] | null; // Profile
     updatePost: NexusGenRootTypes['Post']; // Post!
   }
+  PairProgrammingCount: { // field return type
+    count: number; // Int!
+    profile: NexusGenRootTypes['Profile']; // Profile!
+  }
   Post: { // field return type
     completedAt: NexusGenScalars['DateTime'] | null; // DateTime
     createdAt: NexusGenScalars['DateTime']; // DateTime!
@@ -160,7 +168,9 @@ export interface NexusGenFieldTypes {
   }
   Query: { // field return type
     ListDrivenSkills: NexusGenRootTypes['LearnedSkill'][]; // [LearnedSkill!]!
+    ListDriverPostsRanking: NexusGenRootTypes['PairProgrammingCount'][]; // [PairProgrammingCount!]!
     ListNavigatedSkills: NexusGenRootTypes['LearnedSkill'][]; // [LearnedSkill!]!
+    ListNavigatorPostsRanking: NexusGenRootTypes['PairProgrammingCount'][]; // [PairProgrammingCount!]!
     accessToken: NexusGenRootTypes['Video']; // Video!
     communities: NexusGenRootTypes['Community'][]; // [Community!]!
     feed: NexusGenRootTypes['Post'][]; // [Post!]!
@@ -231,6 +241,10 @@ export interface NexusGenFieldTypeNames {
     updateMyProfile: 'Profile'
     updatePost: 'Post'
   }
+  PairProgrammingCount: { // field return type name
+    count: 'Int'
+    profile: 'Profile'
+  }
   Post: { // field return type name
     completedAt: 'DateTime'
     createdAt: 'DateTime'
@@ -254,7 +268,9 @@ export interface NexusGenFieldTypeNames {
   }
   Query: { // field return type name
     ListDrivenSkills: 'LearnedSkill'
+    ListDriverPostsRanking: 'PairProgrammingCount'
     ListNavigatedSkills: 'LearnedSkill'
+    ListNavigatorPostsRanking: 'PairProgrammingCount'
     accessToken: 'Video'
     communities: 'Community'
     feed: 'Post'

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -45,6 +45,11 @@ type Mutation {
   updatePost(description: String, id: String!, requiredSkillsIds: [Int], title: String): Post!
 }
 
+type PairProgrammingCount {
+  count: Int!
+  profile: Profile!
+}
+
 type Post {
   completedAt: DateTime
   createdAt: DateTime!
@@ -70,7 +75,9 @@ type Profile {
 
 type Query {
   ListDrivenSkills: [LearnedSkill!]!
+  ListDriverPostsRanking: [PairProgrammingCount!]!
   ListNavigatedSkills: [LearnedSkill!]!
+  ListNavigatorPostsRanking: [PairProgrammingCount!]!
   accessToken(identity: String, room: String): Video!
   communities: [Community!]!
   feed: [Post!]!

--- a/api/src/graphql/PairProgrammingCount.ts
+++ b/api/src/graphql/PairProgrammingCount.ts
@@ -1,0 +1,72 @@
+import { extendType, objectType } from "nexus";
+
+export const PairProgrammingCountObject = objectType({
+  name: "PairProgrammingCount",
+  definition(t) {
+    t.nonNull.field("profile", { type: "Profile" });
+    t.nonNull.int("count");
+  },
+});
+
+export const PairProgrammingCountQuery = extendType({
+  type: "Query",
+  definition(t) {
+    t.nonNull.list.nonNull.field("ListNavigatorPostsRanking", {
+      type: "PairProgrammingCount",
+      async resolve(parent, args, context) {
+        const { profileId, userId, communityId } = context;
+        if (!userId) {
+          throw new Error("You have to log in");
+        } else if (!profileId) {
+          throw new Error("You have to be in the community");
+        }
+
+        const profiles = await context.prisma.profile.findMany({
+          where: { communityId },
+          include: {
+            navigatorPost: {
+              where: {
+                completedAt: { not: null },
+              },
+            }
+            },
+        });
+        return profiles
+          .map((profile) => ({
+            profile: profile,
+            count: profile.navigatorPost.length,
+          }))
+          .sort((a, b) => b.count - a.count); // 降順にソート
+      },
+    });
+
+    t.nonNull.list.nonNull.field("ListDriverPostsRanking", {
+      type: "PairProgrammingCount",
+      async resolve(parent, args, context) {
+        const { profileId, userId, communityId } = context;
+        if (!userId) {
+          throw new Error("You have to log in");
+        } else if (!profileId) {
+          throw new Error("You have to be in the community");
+        }
+
+        const profiles = await context.prisma.profile.findMany({
+          where: { communityId },
+          include: {
+            driverPost: {
+              where: {
+                completedAt: { not: null },
+              },
+            },
+          },
+        });
+        return profiles
+          .map((profile) => ({
+            profile: profile,
+            count: profile.driverPost.length,
+          }))
+          .sort((a, b) => b.count - a.count); // 降順にソート
+      },
+    });
+  },
+});

--- a/api/src/graphql/Post.ts
+++ b/api/src/graphql/Post.ts
@@ -310,6 +310,7 @@ export const PostMutation = extendType({
         // check if the post exists
         const post = await context.prisma.post.findUnique({
           where: { id: postId },
+          include: { driver: true }
         });
         if (!post) {
           throw new Error("There is no such post");
@@ -329,7 +330,7 @@ export const PostMutation = extendType({
         }
 
         // check if the navigator belongs to the same community
-        if (navigator.communityId != communityId) {
+        if (post.driver?.communityId != communityId) {
           throw new Error("Navigator does not belong to the same community");
         }
 

--- a/api/src/graphql/Post.ts
+++ b/api/src/graphql/Post.ts
@@ -301,7 +301,7 @@ export const PostMutation = extendType({
       },
       async resolve(parent, args, context) {
         const { postId, navigatorId } = args;
-        const { profileId } = context;
+        const { profileId, communityId } = context;
 
         if (!profileId) {
           throw new Error("You have to log in");
@@ -326,6 +326,11 @@ export const PostMutation = extendType({
         });
         if (!navigator) {
           throw new Error("There is no such navigator");
+        }
+
+        // check if the navigator belongs to the same community
+        if (navigator.communityId != communityId) {
+          throw new Error("Navigator does not belong to the same community");
         }
 
         // increment navigator's matching point

--- a/api/src/graphql/index.ts
+++ b/api/src/graphql/index.ts
@@ -7,4 +7,5 @@ export * from "./Video";
 export * from "./Profile";
 export * from "./Community";
 export * from "./LearnedSkill";
+export * from "./PairProgrammingCount";
 export * from "./scalars/Date";


### PR DESCRIPTION
closes #77 

## 実装
同じコミュニティ内で、誰がドライバーをたくさんやっているか、
もしくはナビゲータを多くやっているかを降順で表示するクエリを追加

また、ナビゲータを登録時に誤って別のコミュニティのProfileを登録しないよう、バリデーションの追加

## 試験
completedAtがnonnullなPostのみが集計されているか
同じコミュニティに属するProfileのPostのみで集計されているか

別のコミュニティのProfileIdをPostのnavigatorに指定しようとした時、エラーを出すか