### PR TITLE
パジネーションで要素数返す！+ キーワードフィルタリング

### DIFF
--- a/api/nexus-typegen.ts
+++ b/api/nexus-typegen.ts
@@ -61,13 +61,13 @@ export interface NexusGenObjects {
     id: number; // Int!
   }
   Mutation: {};
-  PaginatedCommunities: { // root type
-    communities: NexusGenRootTypes['Community'][]; // [Community!]!
-    count: number; // Int!
-  }
   PaginatedPosts: { // root type
     count: number; // Int!
     posts: NexusGenRootTypes['Post'][]; // [Post!]!
+  }
+  PaginatedProfiles: { // root type
+    count: number; // Int!
+    profiles: NexusGenRootTypes['Profile'][]; // [Profile!]!
   }
   Post: { // root type
     completedAt?: NexusGenScalars['DateTime'] | null; // DateTime
@@ -145,13 +145,13 @@ export interface NexusGenFieldTypes {
     updateMyProfile: NexusGenRootTypes['Profile'] | null; // Profile
     updatePost: NexusGenRootTypes['Post']; // Post!
   }
-  PaginatedCommunities: { // field return type
-    communities: NexusGenRootTypes['Community'][]; // [Community!]!
-    count: number; // Int!
-  }
   PaginatedPosts: { // field return type
     count: number; // Int!
     posts: NexusGenRootTypes['Post'][]; // [Post!]!
+  }
+  PaginatedProfiles: { // field return type
+    count: number; // Int!
+    profiles: NexusGenRootTypes['Profile'][]; // [Profile!]!
   }
   Post: { // field return type
     completedAt: NexusGenScalars['DateTime'] | null; // DateTime
@@ -181,7 +181,7 @@ export interface NexusGenFieldTypes {
     communities: NexusGenRootTypes['Community'][]; // [Community!]!
     feed: NexusGenRootTypes['Post'][]; // [Post!]!
     messagesByPostId: NexusGenRootTypes['Message'][]; // [Message!]!
-    myCommunities: NexusGenRootTypes['PaginatedCommunities']; // PaginatedCommunities!
+    myCommunities: NexusGenRootTypes['Community'][]; // [Community!]!
     myCurrentCommunity: NexusGenRootTypes['Community'] | null; // Community
     myDrivingPosts: NexusGenRootTypes['Post'][]; // [Post!]!
     myMatchedPosts: NexusGenRootTypes['Post'][]; // [Post!]!
@@ -189,6 +189,7 @@ export interface NexusGenFieldTypes {
     post: NexusGenRootTypes['Post'] | null; // Post
     profile: NexusGenRootTypes['Profile'] | null; // Profile
     profiles: NexusGenRootTypes['Profile'][]; // [Profile!]!
+    profilesInMyCommunity: NexusGenRootTypes['PaginatedProfiles']; // PaginatedProfiles!
     skills: NexusGenRootTypes['Skill'][]; // [Skill!]!
     unmatchedPosts: NexusGenRootTypes['PaginatedPosts']; // PaginatedPosts!
   }
@@ -247,13 +248,13 @@ export interface NexusGenFieldTypeNames {
     updateMyProfile: 'Profile'
     updatePost: 'Post'
   }
-  PaginatedCommunities: { // field return type name
-    communities: 'Community'
-    count: 'Int'
-  }
   PaginatedPosts: { // field return type name
     count: 'Int'
     posts: 'Post'
+  }
+  PaginatedProfiles: { // field return type name
+    count: 'Int'
+    profiles: 'Profile'
   }
   Post: { // field return type name
     completedAt: 'DateTime'
@@ -283,7 +284,7 @@ export interface NexusGenFieldTypeNames {
     communities: 'Community'
     feed: 'Post'
     messagesByPostId: 'Message'
-    myCommunities: 'PaginatedCommunities'
+    myCommunities: 'Community'
     myCurrentCommunity: 'Community'
     myDrivingPosts: 'Post'
     myMatchedPosts: 'Post'
@@ -291,6 +292,7 @@ export interface NexusGenFieldTypeNames {
     post: 'Post'
     profile: 'Profile'
     profiles: 'Profile'
+    profilesInMyCommunity: 'PaginatedProfiles'
     skills: 'Skill'
     unmatchedPosts: 'PaginatedPosts'
   }
@@ -368,15 +370,15 @@ export interface NexusGenArgTypes {
     messagesByPostId: { // args
       postId: string; // String!
     }
-    myCommunities: { // args
-      skip?: number | null; // Int
-      take?: number | null; // Int
-    }
     post: { // args
       id: string; // String!
     }
     profile: { // args
       id: number; // Int!
+    }
+    profilesInMyCommunity: { // args
+      skip?: number | null; // Int
+      take?: number | null; // Int
     }
     unmatchedPosts: { // args
       driverNameFilter?: string | null; // String

--- a/api/nexus-typegen.ts
+++ b/api/nexus-typegen.ts
@@ -380,6 +380,7 @@ export interface NexusGenArgTypes {
     }
     unmatchedPosts: { // args
       driverNameFilter?: string | null; // String
+      keywordFilter?: string | null; // String
       requiredSkillsFilter?: number | null; // Int
       skip?: number | null; // Int
       take?: number | null; // Int

--- a/api/nexus-typegen.ts
+++ b/api/nexus-typegen.ts
@@ -61,6 +61,10 @@ export interface NexusGenObjects {
     id: number; // Int!
   }
   Mutation: {};
+  PaginatedCommunities: { // root type
+    communities: NexusGenRootTypes['Community'][]; // [Community!]!
+    count: number; // Int!
+  }
   Post: { // root type
     completedAt?: NexusGenScalars['DateTime'] | null; // DateTime
     createdAt: NexusGenScalars['DateTime']; // DateTime!
@@ -137,6 +141,10 @@ export interface NexusGenFieldTypes {
     updateMyProfile: NexusGenRootTypes['Profile'] | null; // Profile
     updatePost: NexusGenRootTypes['Post']; // Post!
   }
+  PaginatedCommunities: { // field return type
+    communities: NexusGenRootTypes['Community'][]; // [Community!]!
+    count: number; // Int!
+  }
   Post: { // field return type
     completedAt: NexusGenScalars['DateTime'] | null; // DateTime
     createdAt: NexusGenScalars['DateTime']; // DateTime!
@@ -165,7 +173,7 @@ export interface NexusGenFieldTypes {
     communities: NexusGenRootTypes['Community'][]; // [Community!]!
     feed: NexusGenRootTypes['Post'][]; // [Post!]!
     messagesByPostId: NexusGenRootTypes['Message'][]; // [Message!]!
-    myCommunities: NexusGenRootTypes['Community'][]; // [Community!]!
+    myCommunities: NexusGenRootTypes['PaginatedCommunities']; // PaginatedCommunities!
     myCurrentCommunity: NexusGenRootTypes['Community'] | null; // Community
     myDrivingPosts: NexusGenRootTypes['Post'][]; // [Post!]!
     myMatchedPosts: NexusGenRootTypes['Post'][]; // [Post!]!
@@ -231,6 +239,10 @@ export interface NexusGenFieldTypeNames {
     updateMyProfile: 'Profile'
     updatePost: 'Post'
   }
+  PaginatedCommunities: { // field return type name
+    communities: 'Community'
+    count: 'Int'
+  }
   Post: { // field return type name
     completedAt: 'DateTime'
     createdAt: 'DateTime'
@@ -259,7 +271,7 @@ export interface NexusGenFieldTypeNames {
     communities: 'Community'
     feed: 'Post'
     messagesByPostId: 'Message'
-    myCommunities: 'Community'
+    myCommunities: 'PaginatedCommunities'
     myCurrentCommunity: 'Community'
     myDrivingPosts: 'Post'
     myMatchedPosts: 'Post'

--- a/api/nexus-typegen.ts
+++ b/api/nexus-typegen.ts
@@ -65,6 +65,10 @@ export interface NexusGenObjects {
     communities: NexusGenRootTypes['Community'][]; // [Community!]!
     count: number; // Int!
   }
+  PaginatedPosts: { // root type
+    count: number; // Int!
+    posts: NexusGenRootTypes['Post'][]; // [Post!]!
+  }
   Post: { // root type
     completedAt?: NexusGenScalars['DateTime'] | null; // DateTime
     createdAt: NexusGenScalars['DateTime']; // DateTime!
@@ -145,6 +149,10 @@ export interface NexusGenFieldTypes {
     communities: NexusGenRootTypes['Community'][]; // [Community!]!
     count: number; // Int!
   }
+  PaginatedPosts: { // field return type
+    count: number; // Int!
+    posts: NexusGenRootTypes['Post'][]; // [Post!]!
+  }
   Post: { // field return type
     completedAt: NexusGenScalars['DateTime'] | null; // DateTime
     createdAt: NexusGenScalars['DateTime']; // DateTime!
@@ -182,7 +190,7 @@ export interface NexusGenFieldTypes {
     profile: NexusGenRootTypes['Profile'] | null; // Profile
     profiles: NexusGenRootTypes['Profile'][]; // [Profile!]!
     skills: NexusGenRootTypes['Skill'][]; // [Skill!]!
-    unmatchedPosts: NexusGenRootTypes['Post'][]; // [Post!]!
+    unmatchedPosts: NexusGenRootTypes['PaginatedPosts']; // PaginatedPosts!
   }
   Skill: { // field return type
     category: string | null; // String
@@ -243,6 +251,10 @@ export interface NexusGenFieldTypeNames {
     communities: 'Community'
     count: 'Int'
   }
+  PaginatedPosts: { // field return type name
+    count: 'Int'
+    posts: 'Post'
+  }
   Post: { // field return type name
     completedAt: 'DateTime'
     createdAt: 'DateTime'
@@ -280,7 +292,7 @@ export interface NexusGenFieldTypeNames {
     profile: 'Profile'
     profiles: 'Profile'
     skills: 'Skill'
-    unmatchedPosts: 'Post'
+    unmatchedPosts: 'PaginatedPosts'
   }
   Skill: { // field return type name
     category: 'String'

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -94,7 +94,7 @@ type Query {
   profile(id: Int!): Profile
   profiles: [Profile!]!
   skills: [Skill!]!
-  unmatchedPosts(driverNameFilter: String, requiredSkillsFilter: Int, skip: Int, take: Int): PaginatedPosts!
+  unmatchedPosts(driverNameFilter: String, keywordFilter: String, requiredSkillsFilter: Int, skip: Int, take: Int): PaginatedPosts!
 }
 
 type Skill {

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -45,6 +45,11 @@ type Mutation {
   updatePost(description: String, id: String!, requiredSkillsIds: [Int], title: String): Post!
 }
 
+type PaginatedCommunities {
+  communities: [Community!]!
+  count: Int!
+}
+
 type Post {
   completedAt: DateTime
   createdAt: DateTime!
@@ -75,7 +80,7 @@ type Query {
   communities: [Community!]!
   feed: [Post!]!
   messagesByPostId(postId: String!): [Message!]!
-  myCommunities(skip: Int, take: Int): [Community!]!
+  myCommunities(skip: Int, take: Int): PaginatedCommunities!
   myCurrentCommunity: Community
   myDrivingPosts: [Post!]!
   myMatchedPosts: [Post!]!

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -50,6 +50,11 @@ type PaginatedCommunities {
   count: Int!
 }
 
+type PaginatedPosts {
+  count: Int!
+  posts: [Post!]!
+}
+
 type Post {
   completedAt: DateTime
   createdAt: DateTime!
@@ -89,7 +94,7 @@ type Query {
   profile(id: Int!): Profile
   profiles: [Profile!]!
   skills: [Skill!]!
-  unmatchedPosts(driverNameFilter: String, requiredSkillsFilter: Int, skip: Int, take: Int): [Post!]!
+  unmatchedPosts(driverNameFilter: String, requiredSkillsFilter: Int, skip: Int, take: Int): PaginatedPosts!
 }
 
 type Skill {

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -45,14 +45,14 @@ type Mutation {
   updatePost(description: String, id: String!, requiredSkillsIds: [Int], title: String): Post!
 }
 
-type PaginatedCommunities {
-  communities: [Community!]!
-  count: Int!
-}
-
 type PaginatedPosts {
   count: Int!
   posts: [Post!]!
+}
+
+type PaginatedProfiles {
+  count: Int!
+  profiles: [Profile!]!
 }
 
 type Post {
@@ -85,7 +85,7 @@ type Query {
   communities: [Community!]!
   feed: [Post!]!
   messagesByPostId(postId: String!): [Message!]!
-  myCommunities(skip: Int, take: Int): PaginatedCommunities!
+  myCommunities: [Community!]!
   myCurrentCommunity: Community
   myDrivingPosts: [Post!]!
   myMatchedPosts: [Post!]!
@@ -93,6 +93,7 @@ type Query {
   post(id: String!): Post
   profile(id: Int!): Profile
   profiles: [Profile!]!
+  profilesInMyCommunity(skip: Int, take: Int): PaginatedProfiles!
   skills: [Skill!]!
   unmatchedPosts(driverNameFilter: String, keywordFilter: String, requiredSkillsFilter: Int, skip: Int, take: Int): PaginatedPosts!
 }

--- a/api/src/graphql/Community.ts
+++ b/api/src/graphql/Community.ts
@@ -20,6 +20,14 @@ export const Community = objectType({
   },
 });
 
+export const PaginatedCommunities = objectType({
+  name: "PaginatedCommunities",
+  definition(t) {
+    t.nonNull.list.nonNull.field("communities", { type: Community });
+    t.nonNull.int("count");
+  },
+});
+
 export const CommunityQuery = extendType({
   type: "Query",
   definition(t) {
@@ -32,8 +40,8 @@ export const CommunityQuery = extendType({
     });
 
     // List communities that user has
-    t.nonNull.list.nonNull.field("myCommunities", {
-      type: "Community",
+    t.nonNull.field("myCommunities", {
+      type: "PaginatedCommunities",
       args: {
         skip: intArg(),
         take: intArg(),
@@ -51,8 +59,13 @@ export const CommunityQuery = extendType({
           skip: skip as number | undefined,
           take: take as number | undefined,
         });
+        const communities = profiles.map((profile) => profile.community);
+        const count = await context.prisma.profile.count({ where: { userId } });
 
-        return profiles.map((profile) => profile.community);
+        return {
+          communities,
+          count,
+        };
       },
     });
 

--- a/api/src/graphql/Community.ts
+++ b/api/src/graphql/Community.ts
@@ -20,14 +20,6 @@ export const Community = objectType({
   },
 });
 
-export const PaginatedCommunities = objectType({
-  name: "PaginatedCommunities",
-  definition(t) {
-    t.nonNull.list.nonNull.field("communities", { type: Community });
-    t.nonNull.int("count");
-  },
-});
-
 export const CommunityQuery = extendType({
   type: "Query",
   definition(t) {
@@ -40,15 +32,10 @@ export const CommunityQuery = extendType({
     });
 
     // List communities that user has
-    t.nonNull.field("myCommunities", {
-      type: "PaginatedCommunities",
-      args: {
-        skip: intArg(),
-        take: intArg(),
-      },
+    t.nonNull.list.nonNull.field("myCommunities", {
+      type: "Community",
       async resolve(parent, args, context) {
         const { userId } = context;
-        const { skip, take } = args;
         if (!userId) {
           throw new Error("You have to log in");
         }
@@ -56,16 +43,8 @@ export const CommunityQuery = extendType({
         const profiles = await context.prisma.profile.findMany({
           where: { userId },
           include: { community: true },
-          skip: skip as number | undefined,
-          take: take as number | undefined,
         });
-        const communities = profiles.map((profile) => profile.community);
-        const count = await context.prisma.profile.count({ where: { userId } });
-
-        return {
-          communities,
-          count,
-        };
+        return profiles.map((profile) => profile.community);
       },
     });
 

--- a/api/src/graphql/Post.ts
+++ b/api/src/graphql/Post.ts
@@ -85,12 +85,19 @@ export const PostQuery = extendType({
       args: {
         driverNameFilter: stringArg(),
         requiredSkillsFilter: intArg(),
+        keywordFilter: stringArg(),
         skip: intArg(),
         take: intArg(),
       },
       async resolve(parent, args, context) {
         const { profileId, communityId } = context;
-        const { driverNameFilter, requiredSkillsFilter, skip, take } = args;
+        const {
+          driverNameFilter,
+          requiredSkillsFilter,
+          keywordFilter,
+          skip,
+          take,
+        } = args;
         if (!profileId || !communityId) {
           throw new Error("You have to be in community");
         }
@@ -128,6 +135,12 @@ export const PostQuery = extendType({
               },
             },
           };
+        }
+        if (keywordFilter) {
+          where.OR = [
+            { title: { contains: keywordFilter } },
+            { description: { contains: keywordFilter } },
+          ];
         }
 
         const posts = await context.prisma.post.findMany({

--- a/api/src/graphql/Post.ts
+++ b/api/src/graphql/Post.ts
@@ -51,6 +51,14 @@ export const Post = objectType({
   },
 });
 
+export const PaginatedPosts = objectType({
+  name: "PaginatedPosts",
+  definition(t) {
+    t.nonNull.list.nonNull.field("posts", { type: Post });
+    t.nonNull.int("count");
+  },
+});
+
 export const PostQuery = extendType({
   type: "Query",
   definition(t) {
@@ -72,8 +80,8 @@ export const PostQuery = extendType({
         });
       },
     });
-    t.nonNull.list.nonNull.field("unmatchedPosts", {
-      type: "Post",
+    t.nonNull.field("unmatchedPosts", {
+      type: "PaginatedPosts",
       args: {
         driverNameFilter: stringArg(),
         requiredSkillsFilter: intArg(),
@@ -122,11 +130,14 @@ export const PostQuery = extendType({
           };
         }
 
-        return context.prisma.post.findMany({
+        const posts = await context.prisma.post.findMany({
           where,
           skip: skip as number | undefined,
           take: take as number | undefined,
         });
+        const count = await context.prisma.post.count({ where });
+
+        return { posts, count };
       },
     });
     t.nonNull.list.nonNull.field("myDrivingPosts", {


### PR DESCRIPTION
closes https://github.com/42supporters-hackason/pair-pro/issues/170

## 参考

- https://github.com/42supporters-hackason/P2P-matching/pull/147
- [GraphQL Filtering, Pagination & Sorting Tutorial with TypeScript](https://www.howtographql.com/typescript-apollo/8-filtering-pagination-and-sorting/)

## 実装

- `count`を持つ新しいオブジェクトを定義
- それを返り値に含めた
- キーワードは、`title`か `desc`とマッチしたらOK

## 気になったところ

GraphQLのtutorialだとIDっていうのをプロパティに持っていて、今回は実装してないです。（引数が同じだと同じIDになるので、キャッシングとかに使うのかと思ってます）
![Screen Shot 2022-08-20 at 13 38 07](https://user-images.githubusercontent.com/69781798/185729124-d0426185-fcdb-4965-9c27-262eb7fb6b34.png)

## Test

引数なし
![Screen Shot 2022-08-20 at 13 40 56](https://user-images.githubusercontent.com/69781798/185729172-55d8a84c-2f1e-4397-89dc-6a86133cd894.png)

`take` `skip` 指定あり
![Screen Shot 2022-08-20 at 13 41 16](https://user-images.githubusercontent.com/69781798/185729177-d4b34f25-3ecf-442a-9fc9-5126858b20bf.png)

値がないフィルタリング
![Screen Shot 2022-08-20 at 13 42 04](https://user-images.githubusercontent.com/69781798/185729202-cf433166-d00b-4cf5-b958-f92aaf8291fa.png)

値があるフィルタリング
![Screen Shot 2022-08-20 at 13 42 45](https://user-images.githubusercontent.com/69781798/185729223-09ba3c19-93a5-4273-ab4a-f422eff31402.png)

キーワードのフィルタリング
![Screen Shot 2022-08-20 at 16 49 01](https://user-images.githubusercontent.com/69781798/185734975-7fe8aa12-5179-4408-a1bf-04e7cc9e5f21.png)


languageのrequireとAND
![Screen Shot 2022-08-20 at 16 49 51](https://user-images.githubusercontent.com/69781798/185734996-9c8b39d9-93ab-48fc-b8d8-ca63852cbd90.png)

