### PR TITLE
未読のメッセージがあるポストのquery

### DIFF
--- a/api/nexus-typegen.ts
+++ b/api/nexus-typegen.ts
@@ -58,7 +58,9 @@ export interface NexusGenObjects {
   }
   Message: { // root type
     content: string; // String!
+    createdAt: NexusGenScalars['DateTime']; // DateTime!
     id: number; // Int!
+    isRead?: boolean | null; // Boolean
   }
   Mutation: {};
   PaginatedPosts: { // root type
@@ -131,8 +133,10 @@ export interface NexusGenFieldTypes {
   }
   Message: { // field return type
     content: string; // String!
+    createdAt: NexusGenScalars['DateTime']; // DateTime!
     createdBy: NexusGenRootTypes['Profile']; // Profile!
     id: number; // Int!
+    isRead: boolean | null; // Boolean
     post: NexusGenRootTypes['Post']; // Post!
   }
   Mutation: { // field return type
@@ -145,6 +149,7 @@ export interface NexusGenFieldTypes {
     deletePost: NexusGenRootTypes['Post']; // Post!
     joinCommunity: NexusGenRootTypes['AuthPayLoad']; // AuthPayLoad!
     post: NexusGenRootTypes['Post']; // Post!
+    readMessages: NexusGenRootTypes['Message'][]; // [Message!]!
     registerNavigator: NexusGenRootTypes['Post']; // Post!
     updateCommunity: NexusGenRootTypes['Community']; // Community!
     updateMyProfile: NexusGenRootTypes['Profile'] | null; // Profile
@@ -197,6 +202,7 @@ export interface NexusGenFieldTypes {
     myCurrentCommunity: NexusGenRootTypes['Community'] | null; // Community
     myDrivingPosts: NexusGenRootTypes['Post'][]; // [Post!]!
     myMatchedPosts: NexusGenRootTypes['Post'][]; // [Post!]!
+    myMatchedPostsWithUnreadMessages: NexusGenRootTypes['Post'][]; // [Post!]!
     myProfile: NexusGenRootTypes['Profile']; // Profile!
     post: NexusGenRootTypes['Post'] | null; // Post
     profile: NexusGenRootTypes['Profile'] | null; // Profile
@@ -242,8 +248,10 @@ export interface NexusGenFieldTypeNames {
   }
   Message: { // field return type name
     content: 'String'
+    createdAt: 'DateTime'
     createdBy: 'Profile'
     id: 'Int'
+    isRead: 'Boolean'
     post: 'Post'
   }
   Mutation: { // field return type name
@@ -256,6 +264,7 @@ export interface NexusGenFieldTypeNames {
     deletePost: 'Post'
     joinCommunity: 'AuthPayLoad'
     post: 'Post'
+    readMessages: 'Message'
     registerNavigator: 'Post'
     updateCommunity: 'Community'
     updateMyProfile: 'Profile'
@@ -308,6 +317,7 @@ export interface NexusGenFieldTypeNames {
     myCurrentCommunity: 'Community'
     myDrivingPosts: 'Post'
     myMatchedPosts: 'Post'
+    myMatchedPostsWithUnreadMessages: 'Post'
     myProfile: 'Profile'
     post: 'Post'
     profile: 'Profile'
@@ -365,6 +375,9 @@ export interface NexusGenArgTypes {
       description: string; // String!
       requiredSkillsId: number[]; // [Int!]!
       title: string; // String!
+    }
+    readMessages: { // args
+      postId: string; // String!
     }
     registerNavigator: { // args
       navigatorId: number; // Int!

--- a/api/prisma/migrations/20220821113833_add_is_read_in_message/migration.sql
+++ b/api/prisma/migrations/20220821113833_add_is_read_in_message/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Message" ADD COLUMN     "isRead" BOOLEAN NOT NULL DEFAULT false;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -61,6 +61,7 @@ model Message {
   createdAt DateTime @default(now())
   createdBy Profile @relation(name: "createdBy", fields: [createdById], references: [id])
   createdById Int
+  isRead      Boolean @default(false)
 }
 
 model Skill {

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -25,8 +25,10 @@ type LearnedSkill {
 
 type Message {
   content: String!
+  createdAt: DateTime!
   createdBy: Profile!
   id: Int!
+  isRead: Boolean
   post: Post!
 }
 
@@ -40,6 +42,7 @@ type Mutation {
   deletePost(id: String!): Post!
   joinCommunity(communityId: String!): AuthPayLoad!
   post(description: String!, requiredSkillsId: [Int!]!, title: String!): Post!
+  readMessages(postId: String!): [Message!]!
   registerNavigator(navigatorId: Int!, postId: String!): Post!
   updateCommunity(id: String!, name: String!): Community!
   updateMyProfile(bio: String, name: String): Profile
@@ -98,6 +101,7 @@ type Query {
   myCurrentCommunity: Community
   myDrivingPosts: [Post!]!
   myMatchedPosts: [Post!]!
+  myMatchedPostsWithUnreadMessages: [Post!]!
   myProfile: Profile!
   post(id: String!): Post
   profile(id: Int!): Profile

--- a/api/src/graphql/Message.ts
+++ b/api/src/graphql/Message.ts
@@ -23,7 +23,7 @@ export const MessageObject = objectType({
           .post()) as Post;
       },
     });
-    // TODO createdAt
+    t.nonNull.dateTime("createdAt");
     t.nonNull.string("content");
     t.nonNull.field("createdBy", {
       type: "Profile",
@@ -36,6 +36,7 @@ export const MessageObject = objectType({
           .createdBy()) as Profile;
       },
     });
+    t.boolean("isRead");
   },
 });
 
@@ -49,6 +50,17 @@ export const MessageQuery = extendType({
       },
       async resolve(parent, args, context) {
         const { postId } = args;
+        const { profileId } = context.expectUserJoinedCommunity();
+        const post = await context.prisma.post.findUnique({
+          where: { id: postId },
+        });
+        if (!post) {
+          throw new Error("post doesn't exist");
+        }
+        if (profileId != post.driverId && profileId != post.navigatorId) {
+          throw new Error("no right to see messages");
+        }
+
         return await context.prisma.message.findMany({
           where: { postId },
         });
@@ -84,6 +96,37 @@ export const MessageMutation = extendType({
         // todo: is 'await' necessary? (https://codesandbox.io/s/nexus-example-subscriptions-59kdb?file=/src/schema/index.ts)
         await context.pubsub.publish(postId.toString(), newMessage);
         return newMessage;
+      },
+    });
+
+    t.nonNull.list.nonNull.field("readMessages", {
+      type: "Message",
+      args: {
+        postId: nonNull(stringArg()),
+      },
+      async resolve(parent, args, context) {
+        const { postId } = args;
+        const { profileId } = context.expectUserJoinedCommunity();
+        const post = await context.prisma.post.findUnique({
+          where: { id: postId },
+        });
+        if (!post) {
+          throw new Error("post doesn't exist");
+        }
+        if (profileId != post.driverId && profileId != post.navigatorId) {
+          throw new Error("no right to see messages");
+        }
+
+        const where = { postId, createdById: { not: profileId } };
+        await context.prisma.message.updateMany({
+          where,
+          data: {
+            isRead: true,
+          },
+        });
+        return await context.prisma.message.findMany({
+          where,
+        });
       },
     });
   },


### PR DESCRIPTION
closes https://github.com/42supporters-hackason/pair-pro/issues/168
related to https://github.com/42supporters-hackason/pair-pro/issues/174

## 変更
- `isRead`の追加
- `messagesByPostId`のバリデーション追加（最初ここに `isRead` の変更処理を書こうとして変更しちゃったから、PRのスコープ違うけど許してえ）
- `readMessages` mutationの追加（下の相談参照）
- `myMatchedPostsWithUnreadMessages` query の追加

## 参考
[Prisma Client API (Reference) | Prisma Docs](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#some)

## 相談
@sniper-fly @taisei-13046 

**`isRead` の値をどのように変更するか**

現状、messageを見るエンドポイントは二つ
- 普通にgetリクエスト的なquery
- websocket使うsubscription

websocketで相手が受信したかを確認する方法が分からない
あと、 queryで副作用的にDBをアップデートするのって良いの？

-> とりあえず、 `readMessages`っていうmutation作って、FEには毎回叩いてもらうかなっていう案で実装した



