### PR TITLE
verification後も型に `undefined` が入らないように修正

### DIFF
--- a/api/src/context.ts
+++ b/api/src/context.ts
@@ -12,8 +12,22 @@ export interface Context {
   profileId?: number;
   communityId?: string;
   pubsub: PubSub;
-  expectUserLoggedIn(): Context;
-  expectUserJoinedCommunity(): Context;
+  expectUserLoggedIn(): UserLoggedInContext;
+  expectUserJoinedCommunity(): UserJoinedCommunityContext;
+}
+
+interface UserLoggedInContext {
+  prisma: PrismaClient;
+  pubsub: PubSub;
+  userId: number;
+}
+
+interface UserJoinedCommunityContext {
+  prisma: PrismaClient;
+  pubsub: PubSub;
+  userId: number;
+  profileId: number;
+  communityId: string;
 }
 
 export const context = ({ req }: { req: Request }): Context => {
@@ -28,17 +42,23 @@ export const context = ({ req }: { req: Request }): Context => {
     profileId: token?.profileId,
     communityId: token?.communityId,
     pubsub,
-    expectUserLoggedIn(): Context {
+    expectUserLoggedIn(): UserLoggedInContext {
       if (!this.userId) {
         throw new Error("You have to log in");
       }
-      return this;
+      return { prisma: this.prisma, pubsub: this.pubsub, userId: this.userId };
     },
-    expectUserJoinedCommunity(): Context {
+    expectUserJoinedCommunity(): UserJoinedCommunityContext {
       if (!this.userId || !this.profileId || !this.communityId) {
         throw new Error("You have to join a community");
       }
-      return this;
+      return {
+        prisma: this.prisma,
+        pubsub: this.pubsub,
+        userId: this.userId,
+        profileId: this.profileId,
+        communityId: this.communityId,
+      };
     },
   };
 };

--- a/api/src/graphql/PairProgrammingCount.ts
+++ b/api/src/graphql/PairProgrammingCount.ts
@@ -14,12 +14,7 @@ export const PairProgrammingCountQuery = extendType({
     t.nonNull.list.nonNull.field("ListNavigatorPostsRanking", {
       type: "PairProgrammingCount",
       async resolve(parent, args, context) {
-        const { profileId, userId, communityId } = context;
-        if (!userId) {
-          throw new Error("You have to log in");
-        } else if (!profileId) {
-          throw new Error("You have to be in the community");
-        }
+        const { communityId } = context.expectUserJoinedCommunity();
 
         const profiles = await context.prisma.profile.findMany({
           where: { communityId },
@@ -28,8 +23,8 @@ export const PairProgrammingCountQuery = extendType({
               where: {
                 completedAt: { not: null },
               },
-            }
             },
+          },
         });
         return profiles
           .map((profile) => ({
@@ -43,12 +38,7 @@ export const PairProgrammingCountQuery = extendType({
     t.nonNull.list.nonNull.field("ListDriverPostsRanking", {
       type: "PairProgrammingCount",
       async resolve(parent, args, context) {
-        const { profileId, userId, communityId } = context;
-        if (!userId) {
-          throw new Error("You have to log in");
-        } else if (!profileId) {
-          throw new Error("You have to be in the community");
-        }
+        const { communityId } = context.expectUserJoinedCommunity();
 
         const profiles = await context.prisma.profile.findMany({
           where: { communityId },

--- a/api/src/graphql/Post.ts
+++ b/api/src/graphql/Post.ts
@@ -185,10 +185,8 @@ export const PostQuery = extendType({
     t.nonNull.list.nonNull.field("myCompletedPosts", {
       type: "Post",
       resolve(parent, args, context) {
-        const { profileId } = context;
-        if (!profileId) {
-          throw new Error("You have to log in");
-        }
+        const { profileId } = context.expectUserJoinedCommunity();
+
         return context.prisma.post.findMany({
           where: {
             OR: [{ navigatorId: profileId }, { driverId: profileId }],
@@ -388,13 +386,7 @@ export const PostMutation = extendType({
       },
       async resolve(parent, args, context) {
         const { postId } = args;
-        const { userId, profileId } = context;
-
-        if (!userId) {
-          throw new Error("You have to log in");
-        } else if (!profileId) {
-          throw new Error("You have to be in the community");
-        }
+        const { profileId } = context.expectUserJoinedCommunity();
 
         const post = await context.prisma.post.findUnique({
           where: { id: postId },

--- a/api/src/graphql/Profile.ts
+++ b/api/src/graphql/Profile.ts
@@ -102,11 +102,9 @@ export const ProfileQuery = extendType({
         take: intArg(),
       },
       async resolve(parent, args, context) {
-        const { communityId } = context;
+        const { communityId } = context.expectUserJoinedCommunity();
         const { skip, take } = args;
-        if (!communityId) {
-          throw new Error("You have to log in");
-        }
+
         const profiles = await context.prisma.profile.findMany({
           where: { communityId },
           skip: skip as number | undefined,
@@ -116,7 +114,7 @@ export const ProfileQuery = extendType({
           where: { communityId },
         });
 
-        return {profiles, count}
+        return { profiles, count };
       },
     });
   },


### PR DESCRIPTION
closes https://github.com/42supporters-hackason/pair-pro/issues/145

## モチベ
https://github.com/42supporters-hackason/pair-pro/issues/145#issuecomment-1221530862

## 変更
- 新しい `interface` の追加
- mergeのタイミングの関係でこのメソッド使われてないやつの修正

## 相談
`interface`がうまく理解できておらず、`undefined` を消すところが冗長になってる（ `this.prop` で全て付け替え ）
（ `return this` しようとしたら怒られた）
もっと良い書き方知ってたら教えてほしい！
