### PR TITLE
コミュニティ内でペアプロされているスキルランキングの取得クエリ

### DIFF
--- a/api/nexus-typegen.ts
+++ b/api/nexus-typegen.ts
@@ -73,6 +73,10 @@ export interface NexusGenObjects {
     count: number; // Int!
     profile: NexusGenRootTypes['Profile']; // Profile!
   }
+  PopularSkillsCount: { // root type
+    count: number; // Int!
+    skill: NexusGenRootTypes['Skill']; // Skill!
+  }
   Post: { // root type
     completedAt?: NexusGenScalars['DateTime'] | null; // DateTime
     createdAt: NexusGenScalars['DateTime']; // DateTime!
@@ -162,6 +166,10 @@ export interface NexusGenFieldTypes {
     count: number; // Int!
     profile: NexusGenRootTypes['Profile']; // Profile!
   }
+  PopularSkillsCount: { // field return type
+    count: number; // Int!
+    skill: NexusGenRootTypes['Skill']; // Skill!
+  }
   Post: { // field return type
     completedAt: NexusGenScalars['DateTime'] | null; // DateTime
     createdAt: NexusGenScalars['DateTime']; // DateTime!
@@ -188,6 +196,7 @@ export interface NexusGenFieldTypes {
     ListDriverPostsRanking: NexusGenRootTypes['PairProgrammingCount'][]; // [PairProgrammingCount!]!
     ListNavigatedSkills: NexusGenRootTypes['LearnedSkill'][]; // [LearnedSkill!]!
     ListNavigatorPostsRanking: NexusGenRootTypes['PairProgrammingCount'][]; // [PairProgrammingCount!]!
+    ListPopularSkillsRanking: NexusGenRootTypes['PopularSkillsCount'][]; // [PopularSkillsCount!]!
     accessToken: NexusGenRootTypes['Video']; // Video!
     communities: NexusGenRootTypes['Community'][]; // [Community!]!
     feed: NexusGenRootTypes['Post'][]; // [Post!]!
@@ -273,6 +282,10 @@ export interface NexusGenFieldTypeNames {
     count: 'Int'
     profile: 'Profile'
   }
+  PopularSkillsCount: { // field return type name
+    count: 'Int'
+    skill: 'Skill'
+  }
   Post: { // field return type name
     completedAt: 'DateTime'
     createdAt: 'DateTime'
@@ -299,6 +312,7 @@ export interface NexusGenFieldTypeNames {
     ListDriverPostsRanking: 'PairProgrammingCount'
     ListNavigatedSkills: 'LearnedSkill'
     ListNavigatorPostsRanking: 'PairProgrammingCount'
+    ListPopularSkillsRanking: 'PopularSkillsCount'
     accessToken: 'Video'
     communities: 'Community'
     feed: 'Post'
@@ -386,6 +400,9 @@ export interface NexusGenArgTypes {
     }
   }
   Query: {
+    ListPopularSkillsRanking: { // args
+      take?: number | null; // Int
+    }
     accessToken: { // args
       identity?: string | null; // String
       room?: string | null; // String

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -61,6 +61,11 @@ type PairProgrammingCount {
   profile: Profile!
 }
 
+type PopularSkillsCount {
+  count: Int!
+  skill: Skill!
+}
+
 type Post {
   completedAt: DateTime
   createdAt: DateTime!
@@ -89,6 +94,7 @@ type Query {
   ListDriverPostsRanking: [PairProgrammingCount!]!
   ListNavigatedSkills: [LearnedSkill!]!
   ListNavigatorPostsRanking: [PairProgrammingCount!]!
+  ListPopularSkillsRanking(take: Int): [PopularSkillsCount!]!
   accessToken(identity: String, room: String): Video!
   communities: [Community!]!
   feed: [Post!]!

--- a/api/src/graphql/PopularSkillsCount.ts
+++ b/api/src/graphql/PopularSkillsCount.ts
@@ -1,0 +1,53 @@
+import { UnsignedInt } from "graphql-scalars/mocks";
+import { extendType, intArg, objectType } from "nexus";
+
+export const PopularSkillsCountObject = objectType({
+  name: "PopularSkillsCount",
+  definition(t) {
+    t.nonNull.field("skill", { type: "Skill" });
+    t.nonNull.int("count");
+  },
+});
+
+export const PopularSkillsCountQuery = extendType({
+  type: "Query",
+  definition(t) {
+    t.nonNull.list.nonNull.field("ListPopularSkillsRanking", {
+      type: "PopularSkillsCount",
+      args: {
+        take: intArg(),
+      },
+      async resolve(parent, args, context) {
+        const { communityId } = context.expectUserJoinedCommunity();
+        const { take } = args;
+        const profiles = await context.prisma.profile.findMany({
+          where: { communityId },
+        });
+
+        const skills = await context.prisma.skill.findMany({
+          include: {
+            requiredBy: {
+              where: {
+                driverId: {
+                  in: profiles.map((p) => p.id),
+                },
+                completedAt: { not: null },
+              },
+            },
+          },
+        });
+
+        // take に任意の値があったとき、引数を２つ展開する。
+        // takeに値がない時、引数はないので展開されず、sliceは配列に手を加えない
+        const sliceArg = take ? [0, take] : [];
+        return skills
+          .sort((a, b) => b.requiredBy.length - a.requiredBy.length)
+          .map((skill) => ({
+            skill,
+            count: skill.requiredBy.length,
+          }))
+          .slice(...sliceArg); // スプレッド構文
+      },
+    });
+  },
+});

--- a/api/src/graphql/PopularSkillsCount.ts
+++ b/api/src/graphql/PopularSkillsCount.ts
@@ -37,16 +37,16 @@ export const PopularSkillsCountQuery = extendType({
           },
         });
 
-        // take に任意の値があったとき、引数を２つ展開する。
-        // takeに値がない時、引数はないので展開されず、sliceは配列に手を加えない
-        const sliceArg = take ? [0, take] : [];
-        return skills
+        const formattedSkills = skills
           .sort((a, b) => b.requiredBy.length - a.requiredBy.length)
           .map((skill) => ({
             skill,
             count: skill.requiredBy.length,
-          }))
-          .slice(...sliceArg); // スプレッド構文
+          }));
+        if (take) {
+          return formattedSkills.slice(0, take);
+        }
+        return formattedSkills;
       },
     });
   },

--- a/api/src/graphql/index.ts
+++ b/api/src/graphql/index.ts
@@ -8,4 +8,5 @@ export * from "./Profile";
 export * from "./Community";
 export * from "./LearnedSkill";
 export * from "./PairProgrammingCount";
+export * from "./PopularSkillsCount";
 export * from "./scalars/Date";


### PR DESCRIPTION
closes #79 

コミュニティ内で多く使われているスキルのランキングを出せるようにしました。
take 引数を利用して、上位何個のスキルまで要求するかも指定できます。

## 仕様
マッチングしただけ、Postとして作っただけ、ではランキングに集計されず、completePairProgrammingによって完了したPostに含まれていたRequiredSkillsから集計しています。

## 試験観点
- requiredされた回数が多いスキルが正しい順番で表示されているか。
- 完了済みPostを追加した時、ランキングに反映されるか

- takeで任意の数のレコードのみ取得できるか


## 実装イメージ
![Screenshot from 2022-08-22 00-03-21](https://user-images.githubusercontent.com/50983271/185797500-3f398f81-e845-4285-88c7-34dcb49d536f.png)
