### PR TITLE
fix: handle when githubBio is null

### DIFF
--- a/api/src/graphql/Auth.ts
+++ b/api/src/graphql/Auth.ts
@@ -31,9 +31,9 @@ export const AuthMutation = extendType({
       async resolve(_parent, args, context) {
         const { code } = args;
         const access_token = (await getAccessToken(code)) as string;
-        
+
         if (!access_token) {
-          throw new Error("Failed at getting access token")
+          throw new Error("Failed at getting access token");
         }
         const {
           id: githubId,
@@ -50,7 +50,7 @@ export const AuthMutation = extendType({
             data: {
               githubLogin,
               githubId,
-              githubBio,
+              githubBio: githubBio ?? "",
             },
           });
         }


### PR DESCRIPTION
このスクショのエラー解決（するはず）

![](https://cdn.discordapp.com/attachments/917778362766852147/1013770583462395950/2022-08-29_20.22.11.png)

https://docs.github.com/en/graphql/reference/objects#user

![Screen Shot 2022-08-29 at 20 41 58](https://user-images.githubusercontent.com/69781798/187193419-a2cf05bd-018a-471c-893c-9309948f4a12.png)
