### PR TITLE
コミュニティ作者のみコミュニティの名前変更可能

### DIFF
--- a/api/nexus-typegen.ts
+++ b/api/nexus-typegen.ts
@@ -127,6 +127,7 @@ export interface NexusGenFieldTypes {
     user: NexusGenRootTypes['User']; // User!
   }
   Community: { // field return type
+    creator: NexusGenRootTypes['Profile'] | null; // Profile
     id: string; // String!
     name: string; // String!
     profiles: NexusGenRootTypes['Profile'][]; // [Profile!]!
@@ -189,6 +190,7 @@ export interface NexusGenFieldTypes {
   Profile: { // field return type
     bio: string; // String!
     community: NexusGenRootTypes['Community']; // Community!
+    createdCommunities: NexusGenRootTypes['Community'][]; // [Community!]!
     driverPost: NexusGenRootTypes['Post'][]; // [Post!]!
     id: number; // Int!
     matchingPoint: number; // Int!
@@ -247,6 +249,7 @@ export interface NexusGenFieldTypeNames {
     user: 'User'
   }
   Community: { // field return type name
+    creator: 'Profile'
     id: 'String'
     name: 'String'
     profiles: 'Profile'
@@ -309,6 +312,7 @@ export interface NexusGenFieldTypeNames {
   Profile: { // field return type name
     bio: 'String'
     community: 'Community'
+    createdCommunities: 'Community'
     driverPost: 'Post'
     id: 'Int'
     matchingPoint: 'Int'

--- a/api/nexus-typegen.ts
+++ b/api/nexus-typegen.ts
@@ -157,6 +157,7 @@ export interface NexusGenFieldTypes {
     post: NexusGenRootTypes['Post']; // Post!
     registerNavigator: NexusGenRootTypes['Post']; // Post!
     updateCommunity: NexusGenRootTypes['Community']; // Community!
+    updateMyCommunity: NexusGenRootTypes['Community']; // Community!
     updateMyProfile: NexusGenRootTypes['Profile'] | null; // Profile
     updatePost: NexusGenRootTypes['Post']; // Post!
   }
@@ -279,6 +280,7 @@ export interface NexusGenFieldTypeNames {
     post: 'Post'
     registerNavigator: 'Post'
     updateCommunity: 'Community'
+    updateMyCommunity: 'Community'
     updateMyProfile: 'Profile'
     updatePost: 'Post'
   }
@@ -404,6 +406,9 @@ export interface NexusGenArgTypes {
     updateCommunity: { // args
       id: string; // String!
       name: string; // String!
+    }
+    updateMyCommunity: { // args
+      name?: string | null; // String
     }
     updateMyProfile: { // args
       bio?: string | null; // String

--- a/api/prisma/migrations/20220902040715_/migration.sql
+++ b/api/prisma/migrations/20220902040715_/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Community" ADD COLUMN     "creatorId" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "Community" ADD CONSTRAINT "Community_creatorId_fkey" FOREIGN KEY ("creatorId") REFERENCES "Profile"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -14,6 +14,8 @@ model Community {
   id        String   @id @default(uuid())
   name      String
   profiles Profile[] @relation(name: "Community")
+  creator Profile? @relation(name: "CommunityCreator", fields: [creatorId], references: [id])
+  creatorId Int?
 }
 
 model User {
@@ -37,6 +39,7 @@ model Profile {
   userId Int
   community Community @relation(name: "Community", fields: [communityId], references: [id])
   communityId String
+  createdCommunities Community[] @relation(name: "CommunityCreator")
 }
 
 model Post {

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -8,6 +8,7 @@ type AuthPayLoad {
 }
 
 type Community {
+  creator: Profile
   id: String!
   name: String!
   profiles: [Profile!]!
@@ -84,6 +85,7 @@ type Post {
 type Profile {
   bio: String!
   community: Community!
+  createdCommunities: [Community!]!
   driverPost: [Post!]!
   id: Int!
   matchingPoint: Int!

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -46,6 +46,7 @@ type Mutation {
   post(description: String!, requiredSkillsId: [Int!]!, title: String!): Post!
   registerNavigator(navigatorId: Int!, postId: String!): Post!
   updateCommunity(id: String!, name: String!): Community!
+  updateMyCommunity(name: String): Community!
   updateMyProfile(bio: String, name: String): Profile
   updatePost(description: String, id: String!, requiredSkillsIds: [Int], title: String): Post!
 }

--- a/api/src/graphql/Community.ts
+++ b/api/src/graphql/Community.ts
@@ -17,6 +17,14 @@ export const Community = objectType({
           .profiles();
       },
     });
+    t.field("creator", {
+      type: "Profile",
+      resolve(parent, args, context) {
+        return context.prisma.community
+          .findUnique({ where: { id: parent.id } })
+          .creator();
+      }
+    })
   },
 });
 

--- a/api/src/graphql/Profile.ts
+++ b/api/src/graphql/Profile.ts
@@ -52,6 +52,16 @@ export const ProfileObject = objectType({
           .community()) as Community;
       },
     });
+    t.nonNull.list.nonNull.field("createdCommunities", {
+      type: "Community",
+      resolve(parent, args, context) {
+        return context.prisma.profile
+          .findUnique({
+            where: { id: parent.id },
+          })
+          .createdCommunities();
+      }
+    })
   },
 });
 


### PR DESCRIPTION
## 実装
- `createCommunity` する際に `creatorId` の設定（今までは、 `joinCommunity` の際に `profile` を作っていたのを変更）（一回、 この`community` と `profile` にリレーションが二つあるせいで、一回どっちも作ってから、 `community` をアップデートするっていうだるい感じのことになってる。。。良い方法知ってたらご教授ください）
- `updateMyCommunity` で `community` の `creator` だったら、編集できる