### PR TITLE
profileの論理削除実装

### DIFF
--- a/api/prisma/migrations/20220921020354_alter_hard_delete_into_soft_delete/migration.sql
+++ b/api/prisma/migrations/20220921020354_alter_hard_delete_into_soft_delete/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Profile" ADD COLUMN     "deletedAt" TIMESTAMP(3);

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -42,6 +42,7 @@ model Profile {
   community          Community   @relation(name: "Community", fields: [communityId], references: [id])
   communityId        String
   createdCommunities Community[] @relation(name: "CommunityCreator")
+  deletedAt          DateTime?
 }
 
 // User one-one Setting. boolやenumで管理するような設定項目をUserから分離

--- a/api/src/graphql/Post.ts
+++ b/api/src/graphql/Post.ts
@@ -103,7 +103,9 @@ export const PostQuery = extendType({
 
         const profileIds = (
           await context.prisma.profile.findMany({
-            where: { communityId },
+            where: {
+              AND: [{ communityId }, { deletedAt: null }],
+            },
           })
         ).map((p) => p.id);
 
@@ -375,8 +377,10 @@ export const PostMutation = extendType({
         }
 
         // check if the navigator exists
-        const navigator = await context.prisma.profile.findUnique({
-          where: { id: navigatorId },
+        const navigator = await context.prisma.profile.findFirst({
+          where: {
+            AND: [{ id: navigatorId }, { deletedAt: null }],
+          },
         });
         if (!navigator) {
           throw new Error("There is no such navigator");

--- a/api/src/graphql/User.ts
+++ b/api/src/graphql/User.ts
@@ -15,7 +15,9 @@ export const UserObject = objectType({
           .findUnique({
             where: { id: parent.id },
           })
-          .profiles();
+          .profiles({
+            where: { deletedAt: null },
+          });
       },
     });
     t.field("setting", {


### PR DESCRIPTION
closes #212 
closes #161

schema.graphqlの変更はなし

脱退者はプロフィール一覧から表示されないように
自分の所属コミュニティ一覧からも、脱退済みのコミュニティは表示されないように
一度脱退したコミュニティにもう一度入る場合、きちんと反映されるように